### PR TITLE
Update Readme to point to v1 Tailwind documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We have built sections for you, but you will likely want to add more to fit your
 
 ### Custom theme
 
-We use Tailwind CSS for styling. To modify your page's look, you can edit the theme in `/front/tailwind.config.js`. Read the [Tailwind docs](https://tailwindcss.com/docs/theme/) to view all the changes you can make. For example, you can change the primary color like this:
+We use Tailwind CSS for styling. To modify your page's look, you can edit the theme in `/front/tailwind.config.js`. Read the [Tailwind docs](https://v1.tailwindcss.com/docs/theme) to view all the changes you can make. For example, you can change the primary color like this:
 
 ```js
 const { colors } = require(`tailwindcss/defaultTheme`);


### PR DESCRIPTION
Tailwinds has now released v2. Upgrade this repo to Tailwinds v2 isn't really necessary, but this readme points to the default Tailwinds docs, which is for V2. Things like customising colours has now changed, and took me some time to realise I was reading the wrong docs for this repo.