### PR TITLE
fix(meta): set the twitter username in seo.js

### DIFF
--- a/frontend/components/elements/seo.js
+++ b/frontend/components/elements/seo.js
@@ -30,7 +30,8 @@ const Seo = ({ metadata }) => {
       // Only included Twitter data if we have it
       twitter={{
         ...(metadata.twitterCardType && { cardType: metadata.twitterCardType }),
-        ...(metadata.twitterUsername && { cardType: metadata.twitterUsername }),
+          // Handle is the twitter username of the content creator
+        ...(metadata.twitterUsername && { handle: metadata.twitterUsername }),
       }}
     />
   );


### PR DESCRIPTION
In the `Seo` component, the Twitter username wasn't set. Instead, the Twitter card type was duplicated (`{ cardType: metadata.twitterUsername }`). Now, the handle property is set to the Twitter username, preventing overriding of the Twitter `cardType`.